### PR TITLE
update install.rst

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -127,6 +127,9 @@ The following example forwards the URL https://demo.elabftw.net to the docker UR
             proxy_set_header Host      $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	    
+	    # add this if nginx is terminating TLS
+	    proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 


### PR DESCRIPTION
add X-Forwarded-Proto to nginx conf example

I see the X-Forwarded-Proto is in the *apache* section but apparently not the *nginx* section. I had skipped over the apache bit, and ran into this [issue](https://github.com/elabftw/elabftw/issues/540) when configuring behind nginx.