### PR TITLE
Fix docker exec command

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -119,6 +119,8 @@ Make sure your user is in the `docker` group so you can execute docker commands 
     # javascript dependencies (node_modules/ directory)
     docker exec -it elabftw yarn install && yarn run buildall
 
+* Now head to https://localhost:3148 once to let elabftw create the mysql tables
+
 * Enable debug mode to disable the caching of Twig templates
 
 .. code-block:: bash


### PR DESCRIPTION
The name of the image is missing for the yarn install command