### PR TITLE
LDAP: Clarified settings, how to integrate custom cert file

### DIFF
--- a/doc/ldap.rst
+++ b/doc/ldap.rst
@@ -28,8 +28,7 @@ For this to work, eLabFTW needs information from you, which is what the LDAP con
 Sysadmin LDAP settings
 ======================
 
-To find the settings, first go to the "Sysadmin panel" by clicking the link at the bottom left of any page or from the user menu at the top right.
-Then go on the LDAP tab.
+The LDAP settings are found on the LDAP tab of the Sysconfig Panel.
 
 Toggle LDAP login
         This is your general ON/OFF switch to toggle LDAP authentication from the login page.

--- a/doc/ldap.rst
+++ b/doc/ldap.rst
@@ -10,31 +10,73 @@ Configure LDAP authentication
 
 This page describes the configuration of LDAP authentication for an eLabFTW instance.
 
-First go to the Sysconfig panel by click the link at the bottom left of any page or from the user menu. Then go on the LDAP tab.
+How does eLabFTW query LDAP servers?
+========================================
 
-Set the "Toggle LDAP login" to Enabled so the option to authenticate through LDAP will be available from the login page.
+LDAP stands for "Lightweight directory access protocol" and is a common protocol to query databases with user information.
+In general, queries to LDAP servers are performed via functions supplied by ``php``.
+The overall schematic for each query with the options set in the sysadmin menu looks like this
 
-Enter the domain name or IP address of the LDAP server in the "LDAP Host" field.
+1. Connect to the LDAP server (-> TLS?, host, port)
+2. Bind (login) with username and password, or anonymously (-> username, password)
+3. Search for users within a certain region of the LDAP world directory (-> base DN) and extract certain properties/fields (-> filter attribute, team name, email, firstname, lastname)
+4. Unbind (log out)
 
-LDAP Port is 389 by default. Use port 636 for LDAPS or any custom port you might have configured.
+Obviously, for this to work, eLabFTW needs information from you.
+That is what the LDAP configuration options and the next section is for.
 
-"LDAP Base DN" will probably be something like "dc=example,dc=org".
+Sysadmin LDAP settings
+======================
 
-"LDAP Username" is the admin login for LDAP server. Not necessarily admin but at least a user that can query other users.
+To find the settings, first go to the Sysconfig panel by clicking the link at the bottom left of any page or from the user menu.
+Then go on the LDAP tab.
 
-"LDAP Password" is the password associated with the previously set account.
+Toggle LDAP login
+        Set to enabled so the option to authenticate through LDAP will be available from the login page.
 
-"Auth lookup with cn or uid". There is no science here. Try with one, if it doesn't work, try with the other ('cn' or 'uid').
+LDAP Host
+        Enter the domain name or IP address of the LDAP server.
+        This should **not** include the protocol or the port, *i.e.* not ``ldaps://my.ldap.server:636``, but only ``my.ldap.server``.
+        For selecting the protocol and port, use the dedicated "LDAP Port" and "Use TLS" options.
 
-Set "Use TLS" if using LDAPS.
+LDAP Port
+        The port the LDAP server listenes on, 389 by default.
+        Use port 636 for LDAPS or any custom port you might have configured.
 
-"What attribute to look for the team name". The LDAP server will reply with the information associated with the user trying to authenticate. Which field will be the one used to determine the team in which to create the user?
+LDAP Base DN
+        This is the "Distinguished Name" for the search, i.e. which part of the (global) LDAP tree you want to find the users in.
+        It is probably something like ``dc=example,dc=org``, but might also include "Organizational Units", so something like ``ou=myinstitute,dc=example,dc=org``.
+        Importantly, this is something completely different from the LDAP username, even though the notation might be similar.
 
-"Create team sent by server if it doesn't exist already". If the team found doesn't exist already, do you want to create one?
+LDAP Username
+        This is the DN or username that connects (binds) to the LDAP server.
+        Examples include ``myuser`` or ``cn=AnAdminOf,ou=MyUnit,dc=example,dc=org``.
+        The user must have permission to query other users.
 
-"If no team attribute is found, to which team user is assigned?". Use this to add users to this team every time. Useful if the LDAP server doesn't answer with a team attribute that can be used for eLabFTW.
+LDAP Password
+        This password is needed for the authentication on the LDAP server with the username specified above.
 
-The last three fields are to specify the fields to look for for the user email, firstname and lastname.
+Use TLS
+        Select this if using LDAPS (= LDAP with TLS).
+
+By which LDAP attribute the user will be found (default is 'mail')
+        This is the "filter attribute" from above.
+        Common choices include ``cn``, ``uid`` and the default ``mail``.
+        This is the LDAP field that holds the information you want users to enter into the "login" field on the start page.
+
+What attribute to look for the team name
+        The LDAP server will reply with the information associated with the user trying to authenticate.
+        Which field will be the one used to determine the team in which to create the user?
+
+Create team sent by server if it doesn't exist already
+        If the team found doesn't exist already, do you want to create one?
+
+If no team attribute is found, to which team user is assigned?
+        Use this to add users to this team by default.
+        Useful if the LDAP server doesn't answer with a team attribute that can be used for eLabFTW.
+
+What attribute to look for ...
+        The last three fields are to specify the fields to look for for the user email, firstname and lastname.
 
 
-If you encounter difficulties, make sure to get a useful log message before opening an issue: :doc:`see debug documentation <debug>`.
+If you encounter difficulties, make sure to get a useful log message before opening an issue, :doc:`see debug documentation <debug>`.

--- a/doc/ldap.rst
+++ b/doc/ldap.rst
@@ -4,17 +4,18 @@
 Configure LDAP authentication
 *****************************
 
+This page describes the configuration of LDAP authentication for an eLabFTW instance.
+
 .. image:: img/auth.png
     :align: center
     :alt: authentication
 
-This page describes the configuration of LDAP authentication for an eLabFTW instance.
+|
+
 
 How does eLabFTW query LDAP servers?
-========================================
+====================================
 
-LDAP stands for "Lightweight directory access protocol" and is a common protocol to query databases with user information.
-In general, queries to LDAP servers are performed via functions supplied by ``php``.
 The overall schematic for each query with the options set in the sysadmin menu looks like this
 
 1. Connect to the LDAP server (-> TLS?, host, port)
@@ -22,17 +23,16 @@ The overall schematic for each query with the options set in the sysadmin menu l
 3. Search for users within a certain region of the LDAP world directory (-> base DN) and extract certain properties/fields (-> filter attribute, team name, email, firstname, lastname)
 4. Unbind (log out)
 
-Obviously, for this to work, eLabFTW needs information from you.
-That is what the LDAP configuration options and the next section is for.
+For this to work, eLabFTW needs information from you, which is what the LDAP configuration options and the next section are for.
 
 Sysadmin LDAP settings
 ======================
 
-To find the settings, first go to the Sysconfig panel by clicking the link at the bottom left of any page or from the user menu.
+To find the settings, first go to the "Sysadmin panel" by clicking the link at the bottom left of any page or from the user menu at the top right.
 Then go on the LDAP tab.
 
 Toggle LDAP login
-        Set to enabled so the option to authenticate through LDAP will be available from the login page.
+        This is your general ON/OFF switch to toggle LDAP authentication from the login page.
 
 LDAP Host
         Enter the domain name or IP address of the LDAP server.
@@ -40,7 +40,7 @@ LDAP Host
         For selecting the protocol and port, use the dedicated "LDAP Port" and "Use TLS" options.
 
 LDAP Port
-        The port the LDAP server listenes on, 389 by default.
+        The port the LDAP server listens on, 389 by default.
         Use port 636 for LDAPS or any custom port you might have configured.
 
 LDAP Base DN
@@ -125,9 +125,9 @@ You can check this via searching for a known user (like yourself?) via
 
 where you might need to use ``sudo docker`` if you are not ``root``.
 Be sure to substitute the ``<...>`` fields with your values.
-The command above installs the needed ``openldap`` packages in the ``elabftw`` container using alpine linux's package manager ``apk`` and then launches a ldap search query.
+The command above installs the needed ``openldap`` packages in the ``elabftw`` container using Alpine Linux's package manager ``apk`` and then launches a ldap search query.
 ``<filter>`` can for example be ``cn=MyOwnName``, or ``uid=5``.
-If trying to connect to a LDAP server that listenes on a port other than 636, specify it like ``-H 'ldaps://<host>:<port>'``.
+If trying to connect to a LDAP server that listens on a port other than 636, specify it like ``-H 'ldaps://<host>:<port>'``.
 
 For more information on the ``ldapsearch`` command, consider
 


### PR DESCRIPTION
This PR includes two changes in two separate commits:
1. Clarified LDAP and restructured LDAP auth
    - Added short explanation/introduction section
    - Reordered entries to match the web LDAP settings form
    - Used a RST description list for the settings
2. LDAP: Added custom cert file section
    - Added instruction on how to add a custom cert file to the eLabFTW
container and have it read by openldap.

I believe this improves the clarity of the docs in the LDAP section, especially for people not too familiar with `docker` and `LDAP`.
The use of description lists improves the readibility of the section in my eyes.
The section on custom cert files would have saved me quite some time while fiddling around with LDAP auth for my use case.

After all, this is only a suggestion, so feel free to comment, add and adjust. I hope this helps!