### PR TITLE
add warning about docker iptables behaviour

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -68,7 +68,7 @@ Configure eLabFTW
 
 .. warning:: A proper subdomain is required!
 
-.. warning:: Docker creates iptables rules by default at startup. As a result, it will expose your elabftw installation to the public if your server is not running behind a firewall. This will also override restrictions set with packages such as ufw. Consider manually creating some rules on the DOCKER-USER chain if you want to restrict access, see `here <https://docs.docker.com/network/packet-filtering-firewalls/#restrict-connections-to-the-docker-host>`.
+.. warning:: Docker creates iptables rules by default at startup. As a result, it will expose your elabftw installation to the public if your server is not running behind a firewall. This will also override restrictions set with packages such as ufw. Consider manually creating some rules on the DOCKER-USER chain if you want to restrict access, see `here <https://docs.docker.com/network/packet-filtering-firewalls/#restrict-connections-to-the-docker-host>`_.
 
 We will install ``elabctl``, a tool to help you manage the elabftw installation. It is not required to install it but it is quite handy so it is recommended (also it's just a bash script, nothing fancy). If you you do not wish to use ``elabctl`` and just want a YAML config to edit, see instructions below for advanced users.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -68,6 +68,8 @@ Configure eLabFTW
 
 .. warning:: A proper subdomain is required!
 
+.. warning:: Docker creates iptables rules by default at startup. As a result, it will expose your elabftw installation to the public if your server is not running behind a firewall. This will also override restrictions set with packages such as ufw. Consider manually creating some rules on the DOCKER-USER chain if you want to restrict access, see `here <https://docs.docker.com/network/packet-filtering-firewalls/#restrict-connections-to-the-docker-host>`.
+
 We will install ``elabctl``, a tool to help you manage the elabftw installation. It is not required to install it but it is quite handy so it is recommended (also it's just a bash script, nothing fancy). If you you do not wish to use ``elabctl`` and just want a YAML config to edit, see instructions below for advanced users.
 
 


### PR DESCRIPTION
Docker creates by default iptables rules at startup which expose the elabftw container to the public. This also overwrites rules set with packages such as ufw (installed for instance by default on Ubuntu server). While this is not an elabftw specific behaviour or a bug it might take unexperienced users by surprise and create security issues. 
Hence add a warning to the elabftw docs and link to the relevant page of the docker manual.